### PR TITLE
Small math mode fixes

### DIFF
--- a/src/services/parser.ts
+++ b/src/services/parser.ts
@@ -257,7 +257,7 @@ export class Parser {
     }
 
     private mathToAnki(str: string) {
-        let mathBlockRegex = /(\$\$)(.*?)(\$\$)/gi
+        let mathBlockRegex = /(\$\$)(.*?)(\$\$)/gis
         str = str.replace(mathBlockRegex, function (match, p1, p2) {
             return '\\\\(' + escapeMarkdown(p2) + ' \\\\)'
         })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,6 +27,7 @@ export function escapeMarkdown(string: string, skips: string[] = []) {
     [/\*/g, "\\*", "asterisks"],
     [/#/g, "\\#", "number signs"],
     [/\//g, "\\/", "slashes"],
+    [/\\/g, "\\\\", "backslash"],
     [/\(/g, "\\(", "parentheses"],
     [/\)/g, "\\)", "parentheses"],
     [/\[/g, "\\[", "square brackets"],


### PR DESCRIPTION
escapes backslashes in math mode (e.g. necessary for *matrices) and allows line breaks in latex equation mode