### PR TITLE
Fix adding IDs when there is no newline at the end of file

### DIFF
--- a/src/services/cards.ts
+++ b/src/services/cards.ts
@@ -59,6 +59,9 @@ export class CardsService {
             await this.anki.createModels(this.settings.sourceSupport, this.settings.codeHighlightSupport)
             await this.anki.createDeck(deckName)
             this.file = await this.app.vault.read(activeFile)
+            if (!this.file.endsWith("\n")) {
+                this.file += "\n"
+            }
             globalTags = this.parseGlobalTags(this.file)
             // TODO with empty check that does not call ankiCards line
             let ankiBlocks = this.parser.getAnkiIDsBlocks(this.file)


### PR DESCRIPTION
Previously, if the file didn't end with a newline an ID would append incorrectly, like so:
```
question #card 
answer^1623693206572
```