### PR TITLE
bugfix: Spaced Card model not generating properly

### DIFF
--- a/src/services/anki.ts
+++ b/src/services/anki.ts
@@ -222,7 +222,7 @@ export class Anki {
         let frontReversed = `{{Back}}\r\n<p class=\"tags\">{{Tags}}<\/p>\r\n\r\n<script>\r\n    var tagEl = document.querySelector(\'.tags\');\r\n    var tags = tagEl.innerHTML.split(\' \');\r\n    var html = \'\';\r\n    tags.forEach(function(tag) {\r\n\tif (tag) {\r\n\t    var newTag = \'<span class=\"tag\">\' + tag + \'<\/span>\';\r\n           html += newTag;\r\n    \t    tagEl.innerHTML = html;\r\n\t}\r\n    });\r\n    \r\n<\/script>${codeScriptContent}`
         let backReversed = `{{FrontSide}}\n\n<hr id=answer>\n\n{{Front}}${sourceFieldContent}`
         let prompt = `{{Prompt}}\r\n<p class=\"tags\">🧠spaced {{Tags}}<\/p>\r\n\r\n<script>\r\n    var tagEl = document.querySelector(\'.tags\');\r\n    var tags = tagEl.innerHTML.split(\' \');\r\n    var html = \'\';\r\n    tags.forEach(function(tag) {\r\n\tif (tag) {\r\n\t    var newTag = \'<span class=\"tag\">\' + tag + \'<\/span>\';\r\n           html += newTag;\r\n    \t    tagEl.innerHTML = html;\r\n\t}\r\n    });\r\n    \r\n<\/script>${codeScriptContent}`
-        let promptBack = `{{FrontSide}}\n\n<hr id=answer>🧠 Review done.${sourceField}`
+        let promptBack = `{{FrontSide}}\n\n<hr id=answer>🧠 Review done.${sourceFieldContent}`
 
         let classicFields = ["Front", "Back"]
         let promptFields = ["Prompt"]


### PR DESCRIPTION
Fixed a small bug due to which `createModels` API call for spaced cards was returning an error:

```json
{
    "result": null,
    "error": "Card template ⁨1⁩ in notetype '⁨Obsidian-spaced⁩' has a problem.<br>See the preview for more information."
}
```

The issue is with the `Source` field, which was being inserted in the template for spaced cards even if Source Support is not enabled in settings.

Replaced `${sourceField}` with `${sourceFieldContent}` in `anki.ts` where the templates for spaced cards are defined. Tested, works fine for me :)