### PR TITLE
Added hide ID setting

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -55,7 +55,7 @@ export default class ObsidianFlashcard extends Plugin {
 	}
 
 	private getDefaultSettings(): ISettings {
-		return { contextAwareMode: true, sourceSupport: false, codeHighlightSupport: false, inlineID: false, contextSeparator: " > ", deck: "Default", folderBasedDeck: true, flashcardsTag: "card", inlineSeparator: "::", inlineSeparatorReverse: ":::", defaultAnkiTag: "obsidian", ankiConnectPermission: false }
+		return { contextAwareMode: true, sourceSupport: false, codeHighlightSupport: false, inlineID: false, hideID: false, contextSeparator: " > ", deck: "Default", folderBasedDeck: true, flashcardsTag: "card", inlineSeparator: "::", inlineSeparatorReverse: ":::", defaultAnkiTag: "obsidian", ankiConnectPermission: false }
 	}
 
 	private generateCards(activeFile: TFile) {

--- a/src/entities/card.ts
+++ b/src/entities/card.ts
@@ -15,6 +15,7 @@ export abstract class Card {
   mediaBase64Encoded: string[];
   oldTags: string[];
   containsCode: boolean;
+  hideId: boolean;
   modelName: string;
 
   constructor(
@@ -28,7 +29,8 @@ export abstract class Card {
     tags: string[],
     inserted: boolean,
     mediaNames: string[],
-    containsCode = false
+    containsCode = false,
+    hideId: boolean
   ) {
     this.id = id;
     this.deckName = deckName;
@@ -43,6 +45,7 @@ export abstract class Card {
     this.mediaBase64Encoded = [];
     this.oldTags = [];
     this.containsCode = containsCode;
+    this.hideId = hideId;
     this.modelName = "";
   }
 

--- a/src/entities/clozecard.ts
+++ b/src/entities/clozecard.ts
@@ -13,7 +13,8 @@ export class Clozecard extends Card {
     tags: string[] = [],
     inserted = false,
     mediaNames: string[],
-    containsCode: boolean
+    containsCode: boolean,
+    hideId: boolean
   ) {
     super(
       id,
@@ -26,7 +27,8 @@ export class Clozecard extends Card {
       tags,
       inserted,
       mediaNames,
-      containsCode
+      containsCode,
+      hideId
     );
     this.modelName = `Obsidian-cloze`;
     if (fields["Source"]) {
@@ -69,6 +71,10 @@ export class Clozecard extends Card {
   };
 
   public getIdFormat(): string {
-    return "\n^" + this.id.toString();
+    if(this.hideId) {
+      return "\n<!--^" + this.id.toString() + "-->";
+    } else {
+      return "\n^" + this.id.toString();
+    }
   }
 }

--- a/src/entities/flashcard.ts
+++ b/src/entities/flashcard.ts
@@ -13,7 +13,8 @@ export class Flashcard extends Card {
     tags: string[] = [],
     inserted = false,
     mediaNames: string[],
-    containsCode: boolean
+    containsCode: boolean,
+    hideId: boolean
   ) {
     super(
       id,
@@ -26,7 +27,8 @@ export class Flashcard extends Card {
       tags,
       inserted,
       mediaNames,
-      containsCode
+      containsCode,
+      hideId
     );
     this.modelName = this.reversed
       ? `Obsidian-basic-reversed`
@@ -71,6 +73,10 @@ export class Flashcard extends Card {
   };
 
   public getIdFormat(): string {
-    return "^" + this.id.toString() + "\n";
+    if(this.hideId) {
+      return "<!--^" + this.id.toString() + "-->\n"; 
+    } else {
+      return "^" + this.id.toString() + "\n";
+    }
   }
 }

--- a/src/entities/inlinecard.ts
+++ b/src/entities/inlinecard.ts
@@ -13,7 +13,8 @@ export class Inlinecard extends Card {
     tags: string[] = [],
     inserted = false,
     mediaNames: string[],
-    containsCode: boolean
+    containsCode: boolean,
+    hideId: boolean
   ) {
     super(
       id,
@@ -26,7 +27,8 @@ export class Inlinecard extends Card {
       tags,
       inserted,
       mediaNames,
-      containsCode
+      containsCode,
+      hideId
     ); // ! CHANGE []
 
     this.modelName = this.reversed
@@ -72,6 +74,10 @@ export class Inlinecard extends Card {
   };
 
   public getIdFormat(): string {
-    return "^" + this.id.toString();
+    if(this.hideId) {
+      return "<!--^" + this.id.toString() + "-->";
+    } else {
+      return "^" + this.id.toString();
+    }
   }
 }

--- a/src/entities/spacedcard.ts
+++ b/src/entities/spacedcard.ts
@@ -13,7 +13,8 @@ export class Spacedcard extends Card {
     tags: string[] = [],
     inserted = false,
     mediaNames: string[],
-    containsCode: boolean
+    containsCode: boolean,
+    hideId: boolean
   ) {
     super(
       id,
@@ -26,7 +27,8 @@ export class Spacedcard extends Card {
       tags,
       inserted,
       mediaNames,
-      containsCode
+      containsCode,
+      hideId
     );
     this.modelName = `Obsidian-spaced`;
     if (fields["Source"]) {
@@ -69,6 +71,10 @@ export class Spacedcard extends Card {
   };
 
   public getIdFormat(): string {
-    return "^" + this.id.toString() + "\n";
+    if(this.hideId) {
+      return "<!--^" + this.id.toString() + "-->\n";
+    } else {
+      return "^" + this.id.toString() + "\n";
+    }
   }
 }

--- a/src/gui/settings-tab.ts
+++ b/src/gui/settings-tab.ts
@@ -96,6 +96,17 @@ export class SettingsTab extends PluginSettingTab {
         })
       );
 
+      new Setting(containerEl)
+      .setName("Hide IDs")
+      .setDesc("Uses HTMl to comment out and hide IDs. NOTE: Will break all cards that were created before/after changing.")
+      .addToggle((toggle) =>
+        toggle.setValue(plugin.settings.hideID).onChange((value) => {
+          plugin.settings.hideID = value;
+          plugin.saveData(plugin.settings);
+        })
+      );
+
+
     new Setting(containerEl)
       .setName("Folder-based deck name")
       .setDesc("Add ID to end of line for inline cards.")

--- a/src/regex.ts
+++ b/src/regex.ts
@@ -55,13 +55,23 @@ export class Regex {
       /\[\[(.*?)\]\]|#([\p{L}:\-_/]+)|([\p{L}:\-_/]+)/gimu;
     this.tagHierarchy = /\//gm;
 
+
+    // Opening and closing tags for HTML comments
+    let commentOpen = "";
+    let commentClose = "";
+
+    if (settings.hideID) {
+      commentOpen = "<!--";
+      commentClose = "-->";
+    }
+
     // Cards
     const flags = "gimu";
     // https://regex101.com/r/p3yQwY/2
     let str =
       "( {0,3}[#]*)((?:[^\\n]\\n?)+?)(#" +
       settings.flashcardsTag +
-      "(?:[/-]reverse)?)((?: *#[\\p{Letter}\\-\\/_]+)*) *?\\n+((?:[^\\n]\\n?)*?(?=\\^\\d{13}|$))(?:\\^(\\d{13}))?";
+      "(?:[/-]reverse)?)((?: *#[\\p{Letter}\\-\\/_]+)*) *?\\n+((?:[^\\n]\\n?)*?(?=" + commentOpen + "\\^\\d{13}|$))(?:" + commentOpen + "\\^(\\d{13})" + commentClose + ")?";
     this.flashscardsWithTag = new RegExp(str, flags);
 
     // https://regex101.com/r/8wmOo8/1
@@ -71,10 +81,11 @@ export class Regex {
     // sepShortest is the shortest
     if (settings.inlineID) {
       str =
-        "( {0,3}[#]{0,6})?(?:(?:[\\t ]*)(?:\\d.|[-+*]|#{1,6}))?(.+?) ?(" + sepLongest + "|" + sepShortest + ") ?(.+?)((?: *#[\\p{Letter}\\-\\/_]+)+)?(?:\\s+\\^(\\d{13})|$)";
+          "( {0,3}[#]{0,6})?(?:(?:[\\t ]*)(?:\\d.|[-+*]|#{1,6}))?(.+?) ?(" + sepLongest + "|" + sepShortest + ") ?(.+?)((?: *#[\\p{Letter}\\-\\/_]+)+)?(?:\\s+" + commentOpen + "\\^(\\d{13})" + commentClose + "|$)";  
+    
     } else {
       str =
-        "( {0,3}[#]{0,6})?(?:(?:[\\t ]*)(?:\\d.|[-+*]|#{1,6}))?(.+?) ?(" + sepLongest + "|" + sepShortest + ") ?(.+?)((?: *#[\\p{Letter}\\-\\/_]+)+|$)(?:\\n\\^(\\d{13}))?";
+          "( {0,3}[#]{0,6})?(?:(?:[\\t ]*)(?:\\d.|[-+*]|#{1,6}))?(.+?) ?(" + sepLongest + "|" + sepShortest + ") ?(.+?)((?: *#[\\p{Letter}\\-\\/_]+)+)?(?:\\s+" + commentOpen + "\\^(\\d{13})" + commentClose + "|$)";
     }
     this.cardsInlineStyle = new RegExp(str, flags);
 
@@ -82,12 +93,12 @@ export class Regex {
     str =
       "( {0,3}[#]*)((?:[^\\n]\\n?)+?)(#" +
       settings.flashcardsTag +
-      "[/-]spaced)((?: *#[\\p{Letter}-]+)*) *\\n?(?:\\^(\\d{13}))?";
+      "[/-]spaced)((?: *#[\\p{Letter}-]+)*) *\\n?(?:" + commentOpen +"\\^(\\d{13})" + commentClose + ")?";
     this.cardsSpacedStyle = new RegExp(str, flags);
 
     // https://regex101.com/r/cgtnLf/1
 
-    str = "( {0,3}[#]{0,6})?(?:(?:[\\t ]*)(?:\\d.|[-+*]|#{1,6}))?(.*?(==.+?==|\\{.+?\\}).*?)((?: *#[\\w\\-\\/_]+)+|$)(?:\n\\^(\\d{13}))?"
+    str = "( {0,3}[#]{0,6})?(?:(?:[\\t ]*)(?:\\d.|[-+*]|#{1,6}))?(.*?(==.+?==|\\{.+?\\}).*?)((?: *#[\\w\\-\\/_]+)+|$)(?:\n" + commentOpen + "\\^(\\d{13})" + commentClose +")?"
     this.cardsClozeWholeLine = new RegExp(str, flags);
     
     this.singleClozeCurly = /((?:{)(?:(\d):?)?(.+?)(?:}))/g;

--- a/src/services/parser.ts
+++ b/src/services/parser.ts
@@ -7,6 +7,7 @@ import { Spacedcard } from "src/entities/spacedcard";
 import { Clozecard } from "src/entities/clozecard";
 import { escapeMarkdown } from "src/utils";
 import { Card } from "src/entities/card";
+import { settings } from "cluster";
 
 export class Parser {
   private regex: Regex;
@@ -176,6 +177,7 @@ export class Parser {
         fields["Source"] = note;
       }
       const containsCode = this.containsCode([prompt]);
+      const hideId = this.settings.hideID;
 
       const card = new Spacedcard(
         id,
@@ -188,7 +190,8 @@ export class Parser {
         tags,
         inserted,
         medias,
-        containsCode
+        containsCode,
+        hideId
       );
       cards.push(card);
     }
@@ -272,6 +275,7 @@ export class Parser {
         fields["Source"] = note;
       }
       const containsCode = this.containsCode([clozeText]);
+      const hideId = this.settings.hideID;
 
       const card = new Clozecard(
         id,
@@ -284,7 +288,8 @@ export class Parser {
         tags,
         inserted,
         medias,
-        containsCode
+        containsCode,
+        hideId
       );
       cards.push(card);
     }
@@ -346,6 +351,7 @@ export class Parser {
         fields["Source"] = note;
       }
       const containsCode = this.containsCode([question, answer]);
+      const hideId = this.settings.hideID;
 
       const card = new Inlinecard(
         id,
@@ -358,7 +364,8 @@ export class Parser {
         tags,
         inserted,
         medias,
-        containsCode
+        containsCode,
+        hideId
       );
       cards.push(card);
     }
@@ -413,6 +420,7 @@ export class Parser {
         fields["Source"] = note;
       }
       const containsCode = this.containsCode([question, answer]);
+      const hideId = this.settings.hideID;
 
       const card = new Flashcard(
         id,
@@ -425,7 +433,8 @@ export class Parser {
         tags,
         inserted,
         medias,
-        containsCode
+        containsCode,
+        hideId
       );
       cards.push(card);
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,7 @@ export interface ISettings {
   sourceSupport: boolean;
   codeHighlightSupport: boolean;
   inlineID: boolean;
+  hideID: boolean;
   contextSeparator: string;
   deck: string;
   folderBasedDeck: boolean;


### PR DESCRIPTION
When enabled, wraps all IDs in `<!--` and `-->`, making them an HTML comment so that they will be hidden, increasing visibility.

Please forgive me if this is bad GitHub convention; I have never participated in contributing to a project before.

Fixes #83.