### PR TITLE
fixes issue #86

### DIFF
--- a/src/regex.ts
+++ b/src/regex.ts
@@ -61,7 +61,7 @@ export class Regex {
     let str =
       "( {0,3}[#]*)((?:[^\\n]\\n?)+?)(#" +
       settings.flashcardsTag +
-      "(?:[/-]reverse)?)((?: *#[\\p{Letter}\\-\\/_]+)*) *?\\n+((?:[^\\n]\\n?)*?(?=\\^\\d{13}|$))(?:\\^(\\d{13}))?";
+      "(?:[/-]reverse)?)((?: *#[\\p{Number}\\p{Letter}\\-\\/_]+)*) *?\\n+((?:[^\\n]\\n?)*?(?=\\^\\d{13}|$))(?:\\^(\\d{13}))?";
     this.flashscardsWithTag = new RegExp(str, flags);
 
     // https://regex101.com/r/8wmOo8/1


### PR DESCRIPTION
Issue: cards are ignored if they have tags that include a number (#86)

Fix: adjusted the `flashscardsWithTag` `RegExp` so it matches tags that include numbers.

I tested this locally. The following example now generates a card as expected.

```markdown
### Some header #card #my-card-1

Some text
```

Closes #86