### PR TITLE
Allow digits in `globalTagsSplitter`

### DIFF
--- a/src/conf/regex.ts
+++ b/src/conf/regex.ts
@@ -54,7 +54,7 @@ export class Regex {
 
     // https://regex101.com/r/WxuFI2/1
     this.globalTagsSplitter =
-      /\[\[(.*?)\]\]|#([\p{L}:\-_/]+)|([\p{L}:\-_/]+)/gimu;
+      /\[\[(.*?)\]\]|#([\p{L}\d:\-_/]+)|([\p{L}\d:\-_/]+)/gimu;
     this.tagHierarchy = /\//gm;
 
     // Cards


### PR DESCRIPTION
Currently, `globalTagsSplitter` doesn't recognize tags that contain a digit. This might fix it.