### PR TITLE
Fixes creating multipne `cards-deck` lines for newly created cards

### DIFF
--- a/src/services/cards.ts
+++ b/src/services/cards.ts
@@ -230,6 +230,10 @@ export class CardsService {
     let newFrontmatter = "";
     const cardsDeckLine = `cards-deck: ${deckName}\n`;
     if (frontmatter) {
+      if (deckName === obsidian.parseFrontMatterEntry(frontmatter, "cards-deck")) {
+        console.log('Skipping frontmatter update, as there is no change in cards-deck');
+        return;
+      }
       const oldFrontmatter: string = this.file.substring(
         frontmatter.position.start.offset,
         frontmatter.position.end.offset


### PR DESCRIPTION
Currently, if you add a new flash card and import it to anki, then flashcards-obsidian adds a new frontmatter line of 
```
cards-deck: ${yourCardsDeckName}
```

to you file, which is unnecessary and annoying.

This tries to fix the creation of multiple `cards-deck` YAML/frontmatter lines during the process of adding new flash cards to anki.

This is more like a hotfix as I'm not sure if it solves the problem bug completely (or might lead to other problems).