### PR TITLE
Proof of concept: Move flash card context into distinct field

### DIFF
--- a/src/services/parser.ts
+++ b/src/services/parser.ts
@@ -158,11 +158,10 @@ export class Parser {
         : "";
 
       const originalPrompt = match[2].trim();
-      let prompt = contextAware
-        ? [...context, match[2].trim()].join(
-          `${this.settings.contextSeparator}`
-        )
-        : match[2].trim();
+
+      let promptContext = context.join(`${this.settings.contextSeparator}`)
+      let prompt = match[2].trim();
+
       let medias: string[] = this.getImageLinks(prompt);
       medias = medias.concat(this.getAudioLinks(prompt));
       prompt = this.parseLine(prompt, vault);
@@ -172,7 +171,7 @@ export class Parser {
       const tags: string[] = this.parseTags(match[4], globalTags);
       const id: number = match[5] ? Number(match[5]) : -1;
       const inserted: boolean = match[5] ? true : false;
-      const fields: any = { Prompt: prompt };
+      const fields: any = { Prompt: prompt, Context: promptContext };
       if (this.settings.sourceSupport) {
         fields["Source"] = note;
       }
@@ -253,12 +252,10 @@ export class Parser {
       }
 
       const originalLine = match[2].trim();
-      // Add context
-      clozeText = contextAware
-        ? [...context, clozeText.trim()].join(
-          `${this.settings.contextSeparator}`
-        )
-        : clozeText.trim();
+      
+      let clozeContext = context.join(`${this.settings.contextSeparator}`)
+      clozeText = clozeText.trim();
+
       let medias: string[] = this.getImageLinks(clozeText);
       medias = medias.concat(this.getAudioLinks(clozeText));
       clozeText = this.parseLine(clozeText, vault);
@@ -268,7 +265,7 @@ export class Parser {
       const tags: string[] = this.parseTags(match[4], globalTags);
       const id: number = match[5] ? Number(match[5]) : -1;
       const inserted: boolean = match[5] ? true : false;
-      const fields: any = { Text: clozeText, Extra: "" };
+      const fields: any = { Text: clozeText, Extra: "", Context: clozeContext };
       if (this.settings.sourceSupport) {
         fields["Source"] = note;
       }
@@ -325,11 +322,10 @@ export class Parser {
         : "";
 
       const originalQuestion = match[2].trim();
-      let question = contextAware
-        ? [...context, match[2].trim()].join(
-          `${this.settings.contextSeparator}`
-        )
-        : match[2].trim();
+
+      let questionContext = context.join(`${this.settings.contextSeparator}`)
+      let question = match[2].trim();
+
       let answer = match[4].trim();
       let medias: string[] = this.getImageLinks(question);
       medias = medias.concat(this.getImageLinks(answer));
@@ -342,7 +338,7 @@ export class Parser {
       const tags: string[] = this.parseTags(match[5], globalTags);
       const id: number = match[6] ? Number(match[6]) : -1;
       const inserted: boolean = match[6] ? true : false;
-      const fields: any = { Front: question, Back: answer };
+      const fields: any = { Front: question, Back: answer, Context: questionContext };
       if (this.settings.sourceSupport) {
         fields["Source"] = note;
       }
@@ -394,11 +390,10 @@ export class Parser {
         : "";
 
       const originalQuestion = match[2].trim();
-      let question = contextAware
-        ? [...context, match[2].trim()].join(
-          `${this.settings.contextSeparator}`
-        )
-        : match[2].trim();
+
+      let questionContext = context.join(`${this.settings.contextSeparator}`)
+      let question = match[2].trim();
+
       let answer = match[5].trim();
       let medias: string[] = this.getImageLinks(question);
       medias = medias.concat(this.getImageLinks(answer));
@@ -414,7 +409,7 @@ export class Parser {
       const tags: string[] = this.parseTags(match[4], globalTags);
       const id: number = match[6] ? Number(match[6]) : -1;
       const inserted: boolean = match[6] ? true : false;
-      const fields: any = { Front: question, Back: answer };
+      const fields: any = { Front: question, Back: answer, Context: questionContext };
       if (this.settings.sourceSupport) {
         fields["Source"] = note;
       }


### PR DESCRIPTION
This is a proof of concept for #146 It moves the cards `context` into an additional/distinct flash card anki field.

This allows easy and independent styling of flashcards.

To test this, you must:

1. Fork/apply this PR
2. Sync Anki between your devices
3. Edit your anki cards and add an extra field `Context` to it. (this needs a force sync, hence step 2)
4. Edit your flash card templates e.g. for the `Obsidian-cloze-source`
```
<div id="context" style="padding:1em;background-color:#444"><small><i>{{Context}}</i></small></div>
{{cloze:Text}}

<script>
    var tagEl = document.querySelector('.tags');
    var tags = tagEl.innerHTML.split(' ');
    var html = '';
    tags.forEach(function(tag) {
	if (tag) {
	    var newTag = '<span class="tag">' + tag + '</span>';
           html += newTag;
    	    tagEl.innerHTML = html;
	}
    });
    
</script>
<script>
	// Hide the Context field if it's empty
	const context = '{{Context}}'
	var contextEl = document.querySelector('#context');
	if (!context) {
		contextEl.style.display="none";
	}
</script>
```
5. Create a new flash card note
```
Flas==card== Test

New flash==card==

# Context Headline 1
## CTC HDL 2
fl==ash==

test ==cloze==
```

- The first two flash cards don't have context. It won't be shown in anki, because of the JS, which hides an empty context
- The last two flash cards have context. It will be shown a bit separated from the card itself. In my opinion this makes it easier to tell, which part of the question is the context and which is the actual question asked.
- It makes the `contextAware` setting more or less obsolete, as users could just delete the `<div id="context" style="padding:1em;background-color:#444"><small><i>{{Context}}</i></small></div>` line from their templates.

This PR is a proof of concept because:
- I have no idea if there's something I'm missing
- Someone with more experience would have to change the anki card models to reflect these changes and add the `Context` field to it
- I don't know if existing users would have to add the `Context` field manually, as I did or if it is possible to add it "silently"
  - (I don't know if silently works because of the needed hard sync in step 2)

Please feel free to build upon this PR and/or use the code and create your own PR to implement this feature