### PR TITLE
Fix subfolder images can not be synced to anki

### DIFF
--- a/src/conf/regex.ts
+++ b/src/conf/regex.ts
@@ -5,6 +5,7 @@ export class Regex {
   wikiImageLinks: RegExp;
   markdownImageLinks: RegExp;
   wikiAudioLinks: RegExp;
+  htmlImgTags: RegExp;
   obsidianCodeBlock: RegExp; // ```code block``
   codeBlock: RegExp;
   mathBlock: RegExp; // $$ latex $$
@@ -40,6 +41,8 @@ export class Regex {
 
     this.wikiAudioLinks =
       /!\[\[(.*\.(?:mp3|webm|wav|m4a|ogg|3gp|flac)).*?\]\]/gim;
+
+    this.htmlImgTags = /<img src=([^>]+)'/g;
 
     // https://regex101.com/r/eqnJeW/1
     this.obsidianCodeBlock = /(?:```(?:.*?\n?)+?```)(?:\n|$)/gim;

--- a/src/conf/regex.ts
+++ b/src/conf/regex.ts
@@ -52,7 +52,7 @@ export class Regex {
     this.mathBlock = /(\$\$)(.*?)(\$\$)/gis;
     this.mathInline = /(\$)(.*?)(\$)/gi;
 
-    this.cardsDeckLine = /cards-deck: [\p{L}]+/giu;
+    this.cardsDeckLine = /cards-deck: [^\n]+/giu;
     this.cardsToDelete = /^\s*(?:\n)(?:\^(\d{13}))(?:\n\s*?)?/gm;
 
     // https://regex101.com/r/WxuFI2/1

--- a/src/entities/flashcard.ts
+++ b/src/entities/flashcard.ts
@@ -1,5 +1,6 @@
 import { codeDeckExtension, sourceDeckExtension } from "src/conf/constants";
 import { Card } from "src/entities/card";
+import {substituteSep} from "src/utils";
 
 export class Flashcard extends Card {
   constructor(
@@ -58,7 +59,7 @@ export class Flashcard extends Card {
     const medias: object[] = [];
     this.mediaBase64Encoded.forEach((data, index) => {
       medias.push({
-        filename: this.mediaNames[index],
+        filename: substituteSep(this.mediaNames[index]),
         data: data,
       });
     });

--- a/src/services/parser.ts
+++ b/src/services/parser.ts
@@ -5,7 +5,7 @@ import { Flashcard } from "../entities/flashcard";
 import { Inlinecard } from "src/entities/inlinecard";
 import { Spacedcard } from "src/entities/spacedcard";
 import { Clozecard } from "src/entities/clozecard";
-import { escapeMarkdown } from "src/utils";
+import {escapeMarkdown, substituteSep} from "src/utils";
 import { Card } from "src/entities/card";
 import { htmlToMarkdown } from 'obsidian';
 
@@ -509,6 +509,9 @@ export class Parser {
   private substituteImageLinks(str: string): string {
     str = str.replace(this.regex.wikiImageLinks, "<img src='$1'>");
     str = str.replace(this.regex.markdownImageLinks, "<img src='$1'>");
+    str = str.replace(this.regex.htmlImgTags,  function (match, p1, p2) {
+      return substituteSep(match);
+    });
 
     return str;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,3 +49,7 @@ export function escapeMarkdown(string: string, skips: string[] = []) {
   export function escapeRegExp(str: string) {
     return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
   }
+
+export function substituteSep(str: string): string {
+  return str.replace("/", "__")
+}


### PR DESCRIPTION
Resolved issue with image attachments in wiki or markdown links not syncing to Anki due to Anki media files not being able to contain folders.