### PR TITLE
Fix white-space collapsing

### DIFF
--- a/src/services/parser.ts
+++ b/src/services/parser.ts
@@ -463,7 +463,7 @@ export class Parser {
           vaultName
         )
       )
-    );
+    ).replace(/&nbsp;/g, ' ');
   }
 
   private getImageLinks(str: string) {


### PR DESCRIPTION
The Anki html renderer does not properly [collapse white space](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space) in the current implementation.

Showdownjs's makeHtml will convert the following string:
```This is a really really long sentence```

into an html snippet like:
```
<p>This&nbsp;is&nbsp;a&nbsp;really&nbsp;really&nbsp;long&nbsp;sentence</p>
```

This normally renders fine, but if you are on a mobile device with limited screen width,  the sentence will be broken at a whatever character hits the maximum width of the card.  Depending on screen width, you may have the first line break in the middle of a word.

This isn't what we want.  We want white space to collapse at the last word that can be fully displayed in a line.  The only way I've found to do this is by replacing ```&nbsp;``` with literal spaces.  In this case, the returned html snippet will be:

```
<p>This is a really really long sentence</p>
```

If the screen width maxes out at the second character in the word `long` then that entire word will be pushed to the next line.