### PR TITLE
Fix creating multipne cards-deck lines for regex can't match

### DIFF
--- a/src/conf/regex.ts
+++ b/src/conf/regex.ts
@@ -49,7 +49,7 @@ export class Regex {
     this.mathBlock = /(\$\$)(.*?)(\$\$)/gis;
     this.mathInline = /(\$)(.*?)(\$)/gi;
 
-    this.cardsDeckLine = /cards-deck: [\p{L}]+/giu;
+    this.cardsDeckLine = /cards-deck: [\p{L}|\p{N}|.]+/giu;
     this.cardsToDelete = /^\s*(?:\n)(?:\^(\d{13}))(?:\n\s*?)?/gm;
 
     // https://regex101.com/r/WxuFI2/1


### PR DESCRIPTION
Since English is not my native language. I am sorry if there is an unclear expression.

I found the `cardsDeckLine regex`   does not match my deck name, which causes new line to be added to frontmatter. As the following gif shows
![Peek-2023-02-07-16-36.gif](https://i.postimg.cc/Qt11SdSG/Peek-2023-02-07-16-36.gif)

![image](https://user-images.githubusercontent.com/62200137/217200093-0acbb764-bfc4-415d-85db-39f56b50e6e4.png)

so i made a change to the regex

![image](https://user-images.githubusercontent.com/62200137/217200427-1d6616c7-f438-46ed-80c1-7a1a0a16ebab.png)

and it fixed this problem for me.

![Peek 2023-02-07 16-38](https://user-images.githubusercontent.com/62200137/217200706-46853a3e-e7e4-4fb6-b3ff-e15a5864522b.gif)

