### PR TITLE
Update settings-tab.ts

### DIFF
--- a/src/gui/settings-tab.ts
+++ b/src/gui/settings-tab.ts
@@ -164,7 +164,7 @@ export class SettingsTab extends PluginSettingTab {
      new Setting(containerEl)
       .setName("Inline card separator")
       .setDesc(
-        "The separator to identifty the inline cards in the notes."
+        "The separator to identify the inline cards in the notes."
       )
       .addText((text) => {
         text
@@ -191,7 +191,7 @@ export class SettingsTab extends PluginSettingTab {
      new Setting(containerEl)
       .setName("Inline reverse card separator")
       .setDesc(
-        "The separator to identifty the inline revese cards in the notes."
+        "The separator to identify the inline revese cards in the notes."
       )
       .addText((text) => {
         text


### PR DESCRIPTION

Small spelling error on line 167 & 194

Currently: "The separator to identifty the inline cards in the notes."

Updated: "The separator to identify the inline cards in the notes."