### PR TITLE
Feat: Generate URI in 'Source' to point directly to a block.

### DIFF
--- a/src/services/cards.ts
+++ b/src/services/cards.ts
@@ -212,6 +212,11 @@ export class CardsService {
           card.reversed ? (total += 2) : total++;
         });
 
+        if(this.settings.sourceSupport){
+            this.parser.updateCardSource(cardsToCreate)
+            this.anki.updateCards(cardsToCreate)
+        }
+
         this.updateFrontmatter(frontmatter, deckName);
         this.writeAnkiBlocks(cardsToCreate);
 

--- a/src/services/parser.ts
+++ b/src/services/parser.ts
@@ -493,14 +493,21 @@ export class Parser {
     return links;
   }
 
+  public updateCardSource(cards: Card[]){
+      for(let card of cards){
+          if(card.id == null) continue
+          card.fields["Source"] = card.fields["Source"].replace("__BLOCK_ID__", String(card.id));
+      }
+  }
+
   private substituteObsidianLinks(str: string, vaultName: string) {
     const linkRegex = /\[\[(.+?)(?:\|(.+?))?\]\]/gim;
     vaultName = encodeURIComponent(vaultName);
 
     return str.replace(linkRegex, (match, filename, rename) => {
       const href = `obsidian://open?vault=${vaultName}&file=${encodeURIComponent(
-        filename
-      )}.md`;
+        filename + "#^__BLOCK_ID__"
+      )}`;
       const fileRename = rename ? rename : filename;
       return `<a href="${href}">${fileRename}</a>`;
     });


### PR DESCRIPTION
Obsidian already supports URI to a block by block ID through the URI 'obsidian://open?file=file#^block_id'. Please note that the 'file#^block_id' part needs to be URI encoded. Therefore, the URI in the 'Source' field will be 'obsidian://open?file={file}%23%5E{block_id}'.