### PR TITLE
Match correct LaTeX expression for the cloze question answer

### DIFF
--- a/src/conf/regex.ts
+++ b/src/conf/regex.ts
@@ -92,7 +92,7 @@ export class Regex {
     str = "( {0,3}[#]{0,6})?(?:(?:[\\t ]*)(?:\\d.|[-+*]|#{1,6}))?(.*?(==.+?==|\\{.+?\\}).*?)((?: *#[\\w\\-\\/_]+)+|$)(?:\n\\^(\\d{13}))?"
     this.cardsClozeWholeLine = new RegExp(str, flags);
     
-    this.singleClozeCurly = /((?:{)(?:(\d):?)?(.+?)(?:}))/g;
+    this.singleClozeCurly = /((?:{)(?:(\d):?)?((\$(.+?)\$)|(.+?))(?:}))/g;
     this.singleClozeHighlight = /((?:==)(.+?)(?:==))/g;
 
     // Matches any embedded block but the one with an used extension from the wikilinks


### PR DESCRIPTION
For the string below
Answers are {$N(\mu\sigma_{1}^{2})$} and {fjeo} 

before: 
{$N(\mu\sigma_{1}
{2})$}
{fjeo}

after:
{$N(\mu\sigma_{1}^{2})$}
{fjeo}